### PR TITLE
Update templates

### DIFF
--- a/packages/generator/src/templates/component.ts
+++ b/packages/generator/src/templates/component.ts
@@ -3,30 +3,33 @@ import { defaultFormat, createIndent, createQuote } from './shared';
 
 const defaultImports: string[] = ['Component', 'h'];
 const defaultOpts: ComponentOptions = {
-    imports: [],
-    prefix: '',
-    selector: 'my-component',
-    tag: 'my-component',
-    styleExt: 'css',
-    className: 'MyComponent',
-    shadow: true
-}
+	imports: ['Host'],
+	prefix: '',
+	selector: 'my-component',
+	tag: 'my-component',
+	styleExt: 'css',
+	className: 'MyComponent',
+	shadow: true
+};
 
-const component = (opts?: Partial<ComponentOptions> & { indent?: string, quotes?: string }) => {
-    if (opts) {
-        opts = { ...defaultFormat, ...defaultOpts, ...opts }
-    } else {
-        opts = { ...defaultFormat, ...defaultOpts }
-    }
-    const indent = createIndent(opts.indent);
-    const quote = createQuote(opts.quotes);
-    
-    const imports = `{ ${[...defaultImports, ...opts.imports].sort().join(', ')} }`;
-    const tag = opts.selector;
-    const styleUrl = `${opts.tag}.${opts.styleExt}`;
-    const shadow = opts.shadow ? `,\n${indent(1)}shadow: true` : '';
+const component = (opts?: Partial<ComponentOptions> & { indent?: string; quotes?: string }) => {
+	if (opts) {
+		opts = { ...defaultFormat, ...defaultOpts, ...opts };
+	} else {
+		opts = { ...defaultFormat, ...defaultOpts };
+	}
+	const indent = createIndent(opts.indent);
+	const quote = createQuote(opts.quotes);
 
-    return `import ${imports} from ${quote('@stencil/core')};
+	const imports = `{ ${[...defaultImports, ...opts.imports]
+		.filter((imp, index, coll) => index === coll.indexOf(imp))
+		.sort()
+		.join(', ')} }`;
+	const tag = opts.selector;
+	const styleUrl = `${opts.tag}.${opts.styleExt}`;
+	const shadow = opts.shadow ? `,\n${indent(1)}shadow: true` : '';
+
+	return `import ${imports} from ${quote('@stencil/core')};
 
 @Component({
 ${indent(1)}tag: ${quote(tag)},
@@ -36,13 +39,13 @@ export class ${opts.className} {
 
 ${indent(1)}render() {
 ${indent(2)}return (
-${indent(3)}<div>
+${indent(3)}<Host>
 ${indent(4)}<p>Hello <code>${tag}</code></p>
-${indent(3)}</div>
+${indent(3)}</Host>
 ${indent(2)});
 ${indent(1)}}
 }
 `;
-}
+};
 
 export default component;

--- a/packages/generator/src/templates/e2e.ts
+++ b/packages/generator/src/templates/e2e.ts
@@ -2,31 +2,33 @@ import { E2EOptions } from './declarations';
 import { defaultFormat, createIndent, createQuote } from './shared';
 
 const defaultOpts: E2EOptions = {
-    selector: 'my-component',
-    className: 'MyComponent',
-    url: '/'
-}
+	selector: 'my-component',
+	className: 'MyComponent',
+	url: '/'
+};
 
-const e2e = (opts?: Partial<E2EOptions> & { indent?: string, quotes?: string }) => {
-    if (opts) {
-        opts = { ...defaultFormat, ...defaultOpts, ...opts }
-    } else {
-        opts = { ...defaultFormat, ...defaultOpts }
-    }
-    const indent = createIndent(opts.indent);
-    const quote = createQuote(opts.quotes);
+const e2e = (opts?: Partial<E2EOptions> & { indent?: string; quotes?: string }) => {
+	if (opts) {
+		opts = { ...defaultFormat, ...defaultOpts, ...opts };
+	} else {
+		opts = { ...defaultFormat, ...defaultOpts };
+	}
+	const indent = createIndent(opts.indent);
+	const quote = createQuote(opts.quotes);
+	const tag = opts.selector;
 
-    return `import { newE2EPage } from ${quote('@stencil/core/testing')};
+	return `import { newE2EPage } from ${quote('@stencil/core/testing')};
 
 describe(${quote(opts.selector)}, () => {
 ${indent(1)}it(${quote('renders')}, async () => {
-${indent(2)}const page = await newE2EPage({ url: ${quote(opts.url)} });
+${indent(2)}const page = await newE2EPage();
+${indent(2)}await page.setContent(${quote(`<${tag}></${tag}>`)});
 
-${indent(2)}const element = await page.find(${quote(opts.selector)});
-${indent(2)}expect(element).toHaveClass(${quote('hydrated')});
+${indent(2)}const element = await page.find(${quote(tag)});
+${indent(2)}expect(element).not.toBeNull();
 ${indent(1)}});
 });
 `;
-}
+};
 
 export default e2e;

--- a/packages/generator/src/templates/spec.ts
+++ b/packages/generator/src/templates/spec.ts
@@ -2,28 +2,42 @@ import { SpecOptions } from './declarations';
 import { defaultFormat, createIndent, createQuote } from './shared';
 
 const defaultOpts: SpecOptions = {
-    tag: 'my-component',
-    selector: 'my-component',
-    className: 'MyComponent'
-}
+	tag: 'my-component',
+	selector: 'my-component',
+	className: 'MyComponent'
+};
 
-const spec = (opts?: Partial<SpecOptions> & { indent?: string, quotes?: string }) => {
-    if (opts) {
-        opts = { ...defaultFormat, ...defaultOpts, ...opts }
-    } else {
-        opts = { ...defaultFormat, ...defaultOpts }
-    }
-    const indent = createIndent(opts.indent);
-    const quote = createQuote(opts.quotes);
+const spec = (opts?: Partial<SpecOptions> & { indent?: string; quotes?: string }) => {
+	if (opts) {
+		opts = { ...defaultFormat, ...defaultOpts, ...opts };
+	} else {
+		opts = { ...defaultFormat, ...defaultOpts };
+	}
+	const indent = createIndent(opts.indent);
+	const quote = createQuote(opts.quotes);
+	const tag = opts.selector;
+	const tagHtml = quote(`<${tag}></${tag}>`);
 
-    return `import { ${opts.className} } from ${quote(`./${opts.tag}`)};
+	return `import { newSpecPage } from ${quote('@stencil/core/testing')};
+import { ${opts.className} } from ${quote(`./${opts.tag}`)};
 
-describe(${quote(opts.selector)}, () => {
+describe(${quote(opts.className)}, () => {
 ${indent(1)}it(${quote('builds')}, () => {
 ${indent(2)}expect(new ${opts.className}()).toBeTruthy();
 ${indent(1)}});
 });
+
+describe(${quote(opts.selector)}, () => {
+${indent(1)}it(${quote(`should render ${tag}`)}, () => {
+${indent(2)}const page = await newSpecPage({
+${indent(3)}components: [${opts.className}],
+${indent(3)}html: ${tagHtml}
+${indent(2)}});
+
+${indent(2)}expect(page.root).toEqualHtml(${tagHtml});
+${indent(1)}});
+});
 `;
-}
+};
 
 export default spec;

--- a/packages/generator/tests/templates/component.spec.ts
+++ b/packages/generator/tests/templates/component.spec.ts
@@ -2,8 +2,8 @@ import component from '../../src/templates/component';
 import test from 'ava';
 
 test('generates file without any options', t => {
-  const sourceText = component();
-  const template = `import { Component, h } from '@stencil/core';
+	const sourceText = component();
+	const template = `import { Component, Host, h } from '@stencil/core';
 
 @Component({
   tag: 'my-component',
@@ -14,88 +14,88 @@ export class MyComponent {
 
   render() {
     return (
-      <div>
+      <Host>
         <p>Hello <code>my-component</code></p>
-      </div>
+      </Host>
     );
   }
 }
 `;
-  
-  t.is(sourceText, template);
-})
+
+	t.is(sourceText, template);
+});
 
 test('ends with a newline', t => {
-  const sourceText = component();
-  t.true(sourceText.endsWith('\n'));
-})
+	const sourceText = component();
+	t.true(sourceText.endsWith('\n'));
+});
 
 test('generates file with tabs', t => {
-  const indent = '\t';
-  const sourceText = component({ indent });
+	const indent = '\t';
+	const sourceText = component({ indent });
 
-  const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
-  t.true(lines.every(ln => ln.startsWith(indent)));
-})
+	const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
+	t.true(lines.every(ln => ln.startsWith(indent)));
+});
 
 test('generates file with 2 spaces', t => {
-  const indent = '  ';
-  const sourceText = component({ indent });
+	const indent = '  ';
+	const sourceText = component({ indent });
 
-  const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
-  t.true(lines.every(ln => ln.startsWith(indent)));
-})
+	const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
+	t.true(lines.every(ln => ln.startsWith(indent)));
+});
 
 test('generates file with 4 spaces', t => {
-  const indent = '    ';
-  const sourceText = component({ indent });
+	const indent = '    ';
+	const sourceText = component({ indent });
 
-  const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
-  t.true(lines.every(ln => ln.startsWith(indent)));
-})
+	const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
+	t.true(lines.every(ln => ln.startsWith(indent)));
+});
 
 test('generates file with single quotes', t => {
-  const sourceText = component({ quotes: `'` });
-  const single = sourceText.indexOf(`'`) > -1;
-  const double = sourceText.indexOf(`"`) > -1;
+	const sourceText = component({ quotes: `'` });
+	const single = sourceText.indexOf(`'`) > -1;
+	const double = sourceText.indexOf(`"`) > -1;
 
-  t.true(single && !double, 'contains double quotes and no single quotes');
-})
+	t.true(single && !double, 'contains double quotes and no single quotes');
+});
 
 test('generates file with double quotes', t => {
-  const sourceText = component({ quotes: `"` });
-  const double = sourceText.indexOf(`"`) > -1;
-  const single = sourceText.indexOf(`'`) > -1;
-  
-  t.true(double && !single, 'contains double quotes and no single quotes');
-})
+	const sourceText = component({ quotes: `"` });
+	const double = sourceText.indexOf(`"`) > -1;
+	const single = sourceText.indexOf(`'`) > -1;
+
+	t.true(double && !single, 'contains double quotes and no single quotes');
+});
 
 test('sets styleUrl based on tag', t => {
-  const sourceText = component({ tag: 'x-test' });
-  t.regex(sourceText, /styleUrl\: 'x-test\.css'/gm);
-})
+	const sourceText = component({ tag: 'x-test' });
+	t.regex(sourceText, /styleUrl\: 'x-test\.css'/gm);
+});
 
 test('sets selector', t => {
-  const sourceText = component({ selector: 'x-test' });
-  t.regex(sourceText, /tag\: 'x-test'/gm);
-})
+	const sourceText = component({ selector: 'x-test' });
+	t.regex(sourceText, /tag\: 'x-test'/gm);
+});
 
 test('sets class name', t => {
-  const sourceText = component({ className: 'XTest' });
-  t.regex(sourceText, /^export class XTest \{/gm);
-})
+	const sourceText = component({ className: 'XTest' });
+	t.regex(sourceText, /^export class XTest \{/gm);
+});
 
 test('sets imports', t => {
-  const sourceText = component({ imports: ['Prop'] });
-  t.regex(sourceText, /^import \{ Component, Prop, h \} from '@stencil\/core'/gm)
+	const sourceText = component({ imports: ['Prop'] });
+	t.regex(sourceText, /^import \{ Component, Prop, h \} from '@stencil\/core'/gm);
 });
 
 test('sets style extension', t => {
-  const sourceText = component({ styleExt: 'scss' });
-  t.regex(sourceText, /styleUrl\: 'my-component\.scss'/gm);
-})
+	const sourceText = component({ styleExt: 'scss' });
+	t.regex(sourceText, /styleUrl\: 'my-component\.scss'/gm);
+});
 
 test('sets shadow', t => {
-  const sourceText = component({ shadow: false });
-  t.false(/shadow/gm.test(sourceText));
-})
+	const sourceText = component({ shadow: false });
+	t.false(/shadow/gm.test(sourceText));
+});

--- a/packages/generator/tests/templates/e2e.spec.ts
+++ b/packages/generator/tests/templates/e2e.spec.ts
@@ -2,78 +2,74 @@ import e2e from '../../src/templates/e2e';
 import test from 'ava';
 
 test('generates file without any options', t => {
-  const sourceText = e2e();
-  const template = `import { newE2EPage } from '@stencil/core/testing';
+	const sourceText = e2e();
+	const template = `import { newE2EPage } from '@stencil/core/testing';
 
 describe('my-component', () => {
   it('renders', async () => {
-    const page = await newE2EPage({ url: '/' });
+    const page = await newE2EPage();
+    await page.setContent('<my-component></my-component>');
 
     const element = await page.find('my-component');
-    expect(element).toHaveClass('hydrated');
+    expect(element).not.toBeNull();
   });
 });
 `;
 
-  t.is(sourceText, template);
-})
+	t.is(sourceText, template);
+});
 
 test('ends with a newline', t => {
-  const sourceText = e2e();
-  t.true(sourceText.endsWith('\n'));
-})
+	const sourceText = e2e();
+	t.true(sourceText.endsWith('\n'));
+});
 
 test('generates file with tabs', t => {
-  const indent = '\t';
-  const sourceText = e2e({ indent });
+	const indent = '\t';
+	const sourceText = e2e({ indent });
 
-  const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
-  t.true(lines.every(ln => ln.startsWith(indent)));
-})
+	const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
+	t.true(lines.every(ln => ln.startsWith(indent)));
+});
 
 test('generates file with 2 spaces', t => {
-  const indent = '  ';
-  const sourceText = e2e({ indent });
+	const indent = '  ';
+	const sourceText = e2e({ indent });
 
-  const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
-  t.true(lines.every(ln => ln.startsWith(indent)));
-})
+	const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
+	t.true(lines.every(ln => ln.startsWith(indent)));
+});
 
 test('generates file with 4 spaces', t => {
-  const indent = '    ';
-  const sourceText = e2e({ indent });
+	const indent = '    ';
+	const sourceText = e2e({ indent });
 
-  const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
-  t.true(lines.every(ln => ln.startsWith(indent)));
-})
+	const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
+	t.true(lines.every(ln => ln.startsWith(indent)));
+});
 
 test('generates file with single quotes', t => {
-  const sourceText = e2e({ quotes: `'` });
-  const single = sourceText.indexOf(`'`) > -1;
-  const double = sourceText.indexOf(`"`) > -1;
+	const sourceText = e2e({ quotes: `'` });
+	const single = sourceText.indexOf(`'`) > -1;
+	const double = sourceText.indexOf(`"`) > -1;
 
-  t.true(single && !double, 'contains double quotes and no single quotes');
-})
+	t.true(single && !double, 'contains double quotes and no single quotes');
+});
 
 test('generates file with double quotes', t => {
-  const sourceText = e2e({ quotes: `"` });
-  const double = sourceText.indexOf(`"`) > -1;
-  const single = sourceText.indexOf(`'`) > -1;
+	const sourceText = e2e({ quotes: `"` });
+	const double = sourceText.indexOf(`"`) > -1;
+	const single = sourceText.indexOf(`'`) > -1;
 
-  t.true(double && !single, 'contains double quotes and no single quotes');
-})
+	t.true(double && !single, 'contains double quotes and no single quotes');
+});
 
 test('describes selector', t => {
-  const sourceText = e2e({ selector: 'x-test' });
-  t.regex(sourceText, /^describe\('x-test'/gm);
-})
+	const sourceText = e2e({ selector: 'x-test' });
+	t.regex(sourceText, /^describe\('x-test'/gm);
+});
 
 test('finds selector', t => {
-  const sourceText = e2e({ selector: 'x-test' });
-  t.regex(sourceText, /await page.find\('x-test'\)\;/gm);
-})
-
-test('sets url', t => {
-  const sourceText = e2e({ url: '/test' });
-  t.regex(sourceText, /url\: '\/test'/gm);
-})
+	const sourceText = e2e({ selector: 'x-test' });
+	t.regex(sourceText, /await page.find\('x-test'\)\;/gm);
+});

--- a/packages/generator/tests/templates/spec.spec.ts
+++ b/packages/generator/tests/templates/spec.spec.ts
@@ -2,75 +2,87 @@ import spec from '../../src/templates/spec';
 import test from 'ava';
 
 test('generates file without any options', t => {
-  const sourceText = spec();
-  const template = `import { MyComponent } from './my-component';
+	const sourceText = spec();
+	const template = `import { newSpecPage } from '@stencil/core/testing';
+import { MyComponent } from './my-component';
 
-describe('my-component', () => {
+describe('MyComponent', () => {
   it('builds', () => {
     expect(new MyComponent()).toBeTruthy();
   });
 });
+
+describe('my-component', () => {
+  it('should render my-component', () => {
+    const page = await newSpecPage({
+      components: [MyComponent],
+      html: '<my-component></my-component>'
+    });
+
+    expect(page.root).toEqualHtml('<my-component></my-component>');
+  });
+});
 `;
-  
-  t.is(sourceText, template);
-})
+
+	t.is(sourceText, template);
+});
 
 test('generates file with tabs', t => {
-  const indent = '\t';
-  const sourceText = spec({ indent });
+	const indent = '\t';
+	const sourceText = spec({ indent });
 
-  const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
-  t.true(lines.every(ln => ln.startsWith(indent)));
-})
+	const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
+	t.true(lines.every(ln => ln.startsWith(indent)));
+});
 
 test('generates file with 2 spaces', t => {
-  const indent = '  ';
-  const sourceText = spec({ indent });
+	const indent = '  ';
+	const sourceText = spec({ indent });
 
-  const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
-  t.true(lines.every(ln => ln.startsWith(indent)));
-})
+	const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
+	t.true(lines.every(ln => ln.startsWith(indent)));
+});
 
 test('generates file with 4 spaces', t => {
-  const indent = '    ';
-  const sourceText = spec({ indent });
+	const indent = '    ';
+	const sourceText = spec({ indent });
 
-  const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
-  t.true(lines.every(ln => ln.startsWith(indent)));
-})
+	const lines = sourceText.split('\n').filter(ln => /^\s+/gm.test(ln));
+	t.true(lines.every(ln => ln.startsWith(indent)));
+});
 
 test('generates file with single quotes', t => {
-  const sourceText = spec({ quotes: `'` });
-  const single = sourceText.indexOf(`'`) > -1;
-  const double = sourceText.indexOf(`"`) > -1;
+	const sourceText = spec({ quotes: `'` });
+	const single = sourceText.indexOf(`'`) > -1;
+	const double = sourceText.indexOf(`"`) > -1;
 
-  t.true(single && !double, 'contains double quotes and no single quotes');
-})
+	t.true(single && !double, 'contains double quotes and no single quotes');
+});
 
 test('generates file with double quotes', t => {
-  const sourceText = spec({ quotes: `"` });
-  const double = sourceText.indexOf(`"`) > -1;
-  const single = sourceText.indexOf(`'`) > -1;
+	const sourceText = spec({ quotes: `"` });
+	const double = sourceText.indexOf(`"`) > -1;
+	const single = sourceText.indexOf(`'`) > -1;
 
-  t.true(double && !single, 'contains double quotes and no single quotes');
-})
+	t.true(double && !single, 'contains double quotes and no single quotes');
+});
 
 test('describes selector', t => {
-  const sourceText = spec({ selector: 'x-test' });
-  t.regex(sourceText, /^describe\('x-test'/gm);
-})
+	const sourceText = spec({ selector: 'x-test' });
+	t.regex(sourceText, /^describe\('x-test'/gm);
+});
 
 test('imports from tag', t => {
-  const sourceText = spec({ tag: 'x-test' });
-  t.regex(sourceText, /from '\.\/x\-test'\;/gm);
-})
+	const sourceText = spec({ tag: 'x-test' });
+	t.regex(sourceText, /from '\.\/x\-test'\;/gm);
+});
 
 test('imports class name', t => {
-  const sourceText = spec({ className: 'TestClass' });
-  t.regex(sourceText, /^import \{ TestClass \}/gm);
-})
+	const sourceText = spec({ className: 'TestClass' });
+	t.regex(sourceText, /^import \{ TestClass \}/gm);
+});
 
 test('expects new class name', t => {
-  const sourceText = spec({ className: 'TestClass' });
-  t.regex(sourceText, /expect\(new TestClass\(\)\)\.toBeTruthy\(\)\;/gm);
-})
+	const sourceText = spec({ className: 'TestClass' });
+	t.regex(sourceText, /expect\(new TestClass\(\)\)\.toBeTruthy\(\)\;/gm);
+});


### PR DESCRIPTION
The component, e2e test, and spec test templates have been updated to match documentation.

Component now uses Host instead of a div.

E2E uses a style similar to that in the documentation, no url needed.

Spec now exposes two ways of doing unit(-ish) testing: by instantiating the component's class and by using newSpecPage.