### PR TITLE
Update @Method() decorated functions to be async

### DIFF
--- a/languageserver/server/src/stencil-service/features/completions/component.ts
+++ b/languageserver/server/src/stencil-service/features/completions/component.ts
@@ -188,13 +188,13 @@ export const DECORATORS: CompletionItem[] = [
 		description: "The `@Method()` decorator is used to expose methods on the public API. Functions decorated with the `@Method()` decorator can be called directly from the element.",
 		insertText: [
 			"@Method()",
-			"${1:methodName}($2) {",
+			"async ${1:methodName}($2) {",
 			"\t$0",
 			"}"
 		],
 		preview: [
 			"@Method()",
-			"methodName() {",
+			"async methodName() {",
 			"\t",
 			"}"
 		],


### PR DESCRIPTION
In the [stencil docs for Methods](https://stenciljs.com/docs/methods) they say:

> Returning a promise is only required for publicly exposed methods which have the @Method decorator. All other component methods are private to the component and are not required to be async.